### PR TITLE
fix: Improve Unity version checks and license activation

### DIFF
--- a/src/unityEditor.ts
+++ b/src/unityEditor.ts
@@ -305,8 +305,12 @@ class UnityEditor {
   ): Promise<Result<void, UnityEditorNotFoundError | UnityCommandError | UnityLicenseError>> {
     console.debug(`Activating Unity license for version ${projectInfo.editorVersion}`);
 
-    if (!serial || !username || !password) {
-      return err(new UnityLicenseError('Missing required credentials', { projectInfo }));
+    const hasMissingCredentials = [serial, username, password].some(
+      (value) => value == null || value.trim().length === 0
+    );
+
+    if (hasMissingCredentials) {
+      return err(new UnityLicenseError("Missing required credentials", { projectInfo }));
     }
 
     const args = ["-quit", "-serial", serial, "-username", username, "-password", password];

--- a/src/unityEditor.ts
+++ b/src/unityEditor.ts
@@ -67,9 +67,7 @@ class UnityEditor {
   public static getUnityExecutablePath(version: string): string {
     const platform = os.platform() as keyof typeof UnityEditor.UNITY_PATHS;
     const unityConfig = UnityEditor.UNITY_PATHS[platform];
-
-    const unityPath = path.join(unityConfig.base, version, unityConfig.executable);
-    return unityPath;
+    return path.join(unityConfig.base, version, unityConfig.executable);
   }
 
   /**
@@ -93,9 +91,8 @@ class UnityEditor {
   public static async isUnityVersionInstalled(version: string): Promise<boolean> {
     try {
       const unityPath = this.getUnityExecutablePath(version);
-      return fs.existsSync(unityPath);
+      return await fs.pathExists(unityPath);
     } catch (error) {
-      console.error(error);
       return false;
     }
   }
@@ -307,6 +304,10 @@ class UnityEditor {
     password: string
   ): Promise<Result<void, UnityEditorNotFoundError | UnityCommandError | UnityLicenseError>> {
     console.debug(`Activating Unity license for version ${projectInfo.editorVersion}`);
+
+    if (!serial || !username || !password) {
+      return err(new UnityLicenseError('Missing required credentials', { projectInfo }));
+    }
 
     const args = ["-quit", "-serial", serial, "-username", username, "-password", password];
 


### PR DESCRIPTION
Refactored getUnityExecutablePath for conciseness and updated isUnityVersionInstalled to use async fs.pathExists. Added credential validation to license activation, returning an error if required credentials are missing.
